### PR TITLE
fix: typo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_ACCESS_KEY_SECRET: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
-  AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+  AWS_REGION: ${{ secrets.AWS_REGION }}
   AWS_BUCKET: ${{ secrets.AWS_BUCKET }}
   AWS_URL: ${{ secrets.AWS_URL }}
 jobs:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ import (
         "secret": config.Env("AWS_ACCESS_KEY_SECRET"),
         "region": config.Env("AWS_REGION"),
         "bucket": config.Env("AWS_BUCKET"),
-        "url": config.Env("S3_URL"),
+        "url": config.Env("AWS_URL"),
         "via": func() (filesystem.Driver, error) {
             return s3facades.S3("s3") // The `s3` value is the `disks` key
         },
@@ -92,5 +92,5 @@ import (
 Run command below to run test(fill your owner s3 configuration):
 
 ```
-AWS_ACCESS_KEY_ID= AWS_ACCESS_KEY_SECRET= AWS_DEFAULT_REGION= AWS_BUCKET= AWS_URL= go test ./...
+AWS_ACCESS_KEY_ID= AWS_ACCESS_KEY_SECRET= AWS_REGION= AWS_BUCKET= AWS_URL= go test ./...
 ```

--- a/s3_test.go
+++ b/s3_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestStorage(t *testing.T) {
 	if os.Getenv("AWS_ACCESS_KEY_ID") == "" {
-		color.Redln("No filesystem tests run, please add S3 configuration: AWS_ACCESS_KEY_ID= AWS_ACCESS_KEY_SECRET= AWS_DEFAULT_REGION= AWS_BUCKET= AWS_URL= go test ./...")
+		color.Redln("No filesystem tests run, please add S3 configuration: AWS_ACCESS_KEY_ID= AWS_ACCESS_KEY_SECRET= AWS_REGION= AWS_BUCKET= AWS_URL= go test ./...")
 		return
 	}
 
@@ -28,7 +28,7 @@ func TestStorage(t *testing.T) {
 	mockConfig.EXPECT().GetString("app.timezone").Return("UTC")
 	mockConfig.EXPECT().GetString("filesystems.disks.s3.key").Return(os.Getenv("AWS_ACCESS_KEY_ID"))
 	mockConfig.EXPECT().GetString("filesystems.disks.s3.secret").Return(os.Getenv("AWS_ACCESS_KEY_SECRET"))
-	mockConfig.EXPECT().GetString("filesystems.disks.s3.region").Return(os.Getenv("AWS_DEFAULT_REGION"))
+	mockConfig.EXPECT().GetString("filesystems.disks.s3.region").Return(os.Getenv("AWS_REGION"))
 	mockConfig.EXPECT().GetString("filesystems.disks.s3.bucket").Return(os.Getenv("AWS_BUCKET"))
 	mockConfig.EXPECT().GetString("filesystems.disks.s3.url").Return(os.Getenv("AWS_URL"))
 	mockConfig.EXPECT().GetString("filesystems.disks.s3.token").Return("")

--- a/setup/setup.go
+++ b/setup/setup.go
@@ -15,7 +15,7 @@ var config = `map[string]any{
         "secret": config.Env("AWS_ACCESS_KEY_SECRET"),
         "region": config.Env("AWS_REGION"),
         "bucket": config.Env("AWS_BUCKET"),
-        "url": config.Env("S3_URL"),
+        "url": config.Env("AWS_URL"),
         "via": func() (filesystem.Driver, error) {
             return s3facades.S3("s3") // The ` + "`s3`" + ` value is the ` + "`disks`" + ` key
         },


### PR DESCRIPTION
## 📑 Description

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

This pull request standardizes the naming conventions for AWS environment variables across the codebase by replacing `AWS_DEFAULT_REGION` with `AWS_REGION` and `S3_URL` with `AWS_URL`. These changes ensure consistency and align with AWS's preferred variable naming.

### Environment Variable Updates:

* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L10-R10): Replaced `AWS_DEFAULT_REGION` with `AWS_REGION` to align with updated naming conventions.

### Documentation Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L53-R53): Updated examples and instructions to use `AWS_REGION` instead of `AWS_DEFAULT_REGION` and `AWS_URL` instead of `S3_URL`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L53-R53) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L95-R95)

### Test Code Updates:

* [`s3_test.go`](diffhunk://#diff-67d46944a5aad1160e4d39495c8d3faf79aa06f06d43351586fa219c85333dfaL21-R21): Modified test setup to use `AWS_REGION` instead of `AWS_DEFAULT_REGION`, ensuring consistency in test configurations. [[1]](diffhunk://#diff-67d46944a5aad1160e4d39495c8d3faf79aa06f06d43351586fa219c85333dfaL21-R21) [[2]](diffhunk://#diff-67d46944a5aad1160e4d39495c8d3faf79aa06f06d43351586fa219c85333dfaL31-R31)

### Configuration Updates:

* [`setup/setup.go`](diffhunk://#diff-d611928452df4fc552aa13b435f1a9c9450b7eb712ce57568571922e8318e930L18-R18): Replaced `S3_URL` with `AWS_URL` in the configuration mapping to align with the standardized variable names.

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [ ] Added test cases for my code
