### PR TITLE
chore: update color package usage to support package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.18.10
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.87.3
 	github.com/gabriel-vasile/mimetype v1.4.10
-	github.com/gookit/color v1.5.4
 	github.com/goravel/framework v1.16.3
 	github.com/stretchr/testify v1.10.0
 )
@@ -34,6 +33,7 @@ require (
 	github.com/dromara/carbon/v2 v2.6.11 // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
+	github.com/gookit/color v1.5.4 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/jmoiron/sqlx v1.4.0 // indirect

--- a/s3.go
+++ b/s3.go
@@ -14,8 +14,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/gabriel-vasile/mimetype"
-	"github.com/gookit/color"
 	"github.com/goravel/framework/http"
+	"github.com/goravel/framework/support/color"
 	"github.com/goravel/framework/support/str"
 
 	"github.com/goravel/framework/contracts/config"
@@ -425,7 +425,7 @@ func (r *S3) WithContext(ctx context.Context) filesystem.Driver {
 
 	driver, err := NewS3(ctx, r.config, r.disk)
 	if err != nil {
-		color.Redf("[S3] init disk error: %+v\n", err)
+		color.Red().Printfln("[S3] init disk error: %+v", err)
 
 		return nil
 	}

--- a/s3_test.go
+++ b/s3_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gookit/color"
+	"github.com/goravel/framework/support/color"
 	"github.com/stretchr/testify/assert"
 
 	contractsfilesystem "github.com/goravel/framework/contracts/filesystem"
@@ -18,7 +18,7 @@ import (
 
 func TestStorage(t *testing.T) {
 	if os.Getenv("AWS_ACCESS_KEY_ID") == "" {
-		color.Redln("No filesystem tests run, please add S3 configuration: AWS_ACCESS_KEY_ID= AWS_ACCESS_KEY_SECRET= AWS_REGION= AWS_BUCKET= AWS_URL= go test ./...")
+		color.Red().Println("No filesystem tests run, please add S3 configuration: AWS_ACCESS_KEY_ID= AWS_ACCESS_KEY_SECRET= AWS_REGION= AWS_BUCKET= AWS_URL= go test ./...")
 		return
 	}
 


### PR DESCRIPTION
## 📑 Description

Replaces direct usage of the external gookit/color package with the internal github.com/goravel/framework/support/color package, and updates the method calls for printing colored output. Additionally, the dependency on gookit/color is now marked as indirect in go.mod.

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [ ] Added test cases for my code
